### PR TITLE
Add accessibility to site, Discord, and Lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# bvanseg.github.io
- Where programmers are made.
+# [bvanseg.github.io](https://bvanseg.github.io)
+Where programmers are made.
+
+[![Discord](https://img.shields.io/discord/609993365832073217?color=7289da&label=discord)](https://discord.gg/Sw3npy4)

--- a/index.md
+++ b/index.md
@@ -2,5 +2,6 @@
 Get started with:
 - [C](courses/C/C.md)
 - [C++](courses/CPP/CPP.md)
+- [Lua](courses/Lua/Lua.md)
 
 [![Discord](https://img.shields.io/discord/609993365832073217?color=7289da&label=discord)](https://discord.gg/Sw3npy4)


### PR DESCRIPTION
These commits force the readme header to function as a link to the site, add a link to the Discord server in the readme, and add Lua to the index page so that people can read it. I should've caught that one yesterday, in all honesty…